### PR TITLE
Add deepseek-qwen-1.5b

### DIFF
--- a/cezo_fl/util/language_utils.py
+++ b/cezo_fl/util/language_utils.py
@@ -20,8 +20,7 @@ SUPPORTED_LLM = {
     "opt-6.7b": "facebook/opt-6.7b",
     "opt-13b": "facebook/opt-13b",
     "opt-30b": "facebook/opt-30b",
-    "phi-1": "microsoft/phi-1",
-    "phi-1.5": "microsoft/phi-1_5",
+    "deepseek-qwen-1.5b": "deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B",
 }
 
 

--- a/cezo_fl/util/model_helpers.py
+++ b/cezo_fl/util/model_helpers.py
@@ -10,11 +10,11 @@ from typing import Iterator, TypeAlias
 
 import torch
 from peft import PeftModel
-from transformers.models.opt.modeling_opt import OPTForCausalLM
+from transformers.modeling_utils import PreTrainedModel
 
 from cezo_fl.util.language_utils import LLMBatchInput
 
-LanguageModel: TypeAlias = OPTForCausalLM | PeftModel
+LanguageModel: TypeAlias = PreTrainedModel | PeftModel
 AllModel: TypeAlias = torch.nn.Module | LanguageModel
 
 
@@ -65,7 +65,7 @@ def get_trainable_model_parameters(
 
 
 def model_forward(model: AllModel, batch_inputs: torch.Tensor | LLMBatchInput):
-    if isinstance(model, (OPTForCausalLM, PeftModel)):
+    if isinstance(model, (PreTrainedModel, PeftModel)):
         assert isinstance(batch_inputs, LLMBatchInput)
         return model(input_ids=batch_inputs.input_ids, attention_mask=batch_inputs.attention_mask)
     elif isinstance(model, torch.nn.Module):

--- a/experiment_helper/experiment_typing.py
+++ b/experiment_helper/experiment_typing.py
@@ -9,6 +9,7 @@ class LargeModel(Enum):
     opt_6p7b = "opt-6.7b"
     opt_13b = "opt-13b"
     opt_30b = "opt-30b"
+    deepseek_qwen_1p5b = "deepseek-qwen-1.5b"
 
 
 class ModelDtype(Enum):

--- a/fed_avg/client.py
+++ b/fed_avg/client.py
@@ -3,7 +3,7 @@ from typing import Iterator, Callable, Any
 import torch
 from peft import PeftModel
 from torch.utils.data import DataLoader
-from transformers.models.opt.modeling_opt import OPTForCausalLM
+from transformers.modeling_utils import PreTrainedModel
 
 from cezo_fl.typing import CriterionType
 from cezo_fl.util.metrics import Metric
@@ -66,7 +66,7 @@ class FedAvgClient:
 
         return train_loss.avg, train_accuracy.avg
 
-    def pull_model(self, server_model: OPTForCausalLM | PeftModel | torch.nn.Module) -> None:
+    def pull_model(self, server_model: PreTrainedModel | PeftModel | torch.nn.Module) -> None:
         with torch.no_grad():
             for p, updated_p in zip(self.model.parameters(), server_model.parameters()):
                 p.set_(updated_p.to(self._device))

--- a/test_model.py
+++ b/test_model.py
@@ -1,0 +1,7 @@
+import torch
+from transformers import AutoModelForCausalLM
+
+hf_model_name = "deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B"
+torch_dtype = torch.float32
+
+model = AutoModelForCausalLM.from_pretrained(hf_model_name, torch_dtype=torch_dtype)


### PR DESCRIPTION
# Summary

- [x] Add deepseek-qwen-1.5b
- [x] Remove phi-1 and phi-1.5, because their error are harder to take care of 

phi-1 model's error
![image](https://github.com/user-attachments/assets/a744da36-72aa-4a84-8639-7030cffca961)

# Evidence
deepseek-qwen-1.5b can be trained using this command.

`python decomfl_main.py --large-model=deepseek-qwen-1.5b --dataset=sst2 --iterations=1000 --train-batch-size=32 --test-batch-size=200 --eval-iterations=25 --num-clients=1 --num-sample-clients=1 --local-update-steps=1 --num-pert=5 --lr=1e-5 --mu=1e-3 --grad-estimate-method=rge-forward --no-optim --model-dtype=float16`

![image](https://github.com/user-attachments/assets/c241bb4d-6335-4cb4-9d5f-f123a810a769)
